### PR TITLE
Error handling using standard error type

### DIFF
--- a/FTAPIKit.xcodeproj/project.pbxproj
+++ b/FTAPIKit.xcodeproj/project.pbxproj
@@ -459,11 +459,11 @@
 					};
 					52D6DA0E1BF000BD002C0205 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 					DD7502791C68FCFC006590AF = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 					};
 					DD75028C1C690C7A006590AF = {
 						CreatedOnToolsVersion = 7.2.1;

--- a/FTAPIKit.xcodeproj/project.pbxproj
+++ b/FTAPIKit.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		E7197F802235266A0059A54A /* MockupBodyPart.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E7197F7B223523A40059A54A /* MockupBodyPart.jpg */; };
 		E7197F812235266A0059A54A /* MockupBodyPart.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E7197F7B223523A40059A54A /* MockupBodyPart.jpg */; };
 		E7197F822235266B0059A54A /* MockupBodyPart.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E7197F7B223523A40059A54A /* MockupBodyPart.jpg */; };
+		E766870B2236FCFE0090DC08 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E766870A2236FCFE0090DC08 /* APIError.swift */; };
+		E766870C2236FCFE0090DC08 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E766870A2236FCFE0090DC08 /* APIError.swift */; };
+		E766870D2236FCFE0090DC08 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E766870A2236FCFE0090DC08 /* APIError.swift */; };
+		E766870E2236FCFE0090DC08 /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E766870A2236FCFE0090DC08 /* APIError.swift */; };
 		E7692824222431CE0031137D /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7692823222431CE0031137D /* MultipartFormData.swift */; };
 		E7692825222431CE0031137D /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7692823222431CE0031137D /* MultipartFormData.swift */; };
 		E7692826222431CE0031137D /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7692823222431CE0031137D /* MultipartFormData.swift */; };
@@ -111,6 +115,7 @@
 		DD75028D1C690C7A006590AF /* FTAPIKit-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FTAPIKit-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E7197F76223510FF0059A54A /* MultipartBodyPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartBodyPart.swift; sourceTree = "<group>"; };
 		E7197F7B223523A40059A54A /* MockupBodyPart.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MockupBodyPart.jpg; sourceTree = "<group>"; };
+		E766870A2236FCFE0090DC08 /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
 		E7692823222431CE0031137D /* MultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		E769282822269D4C0031137D /* OutputStream+Write.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OutputStream+Write.swift"; sourceTree = "<group>"; };
 		E792629C219710A700CDBB7E /* URLSessionAPIAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAPIAdapter.swift; sourceTree = "<group>"; };
@@ -219,6 +224,7 @@
 				E7B774192152752A006E7585 /* APIEndpoint.swift */,
 				E7B774142152752A006E7585 /* APIAdapter.swift */,
 				E7B7741A2152752A006E7585 /* APIAdapter+Types.swift */,
+				E766870A2236FCFE0090DC08 /* APIError.swift */,
 				E792629C219710A700CDBB7E /* URLSessionAPIAdapter.swift */,
 				E7B774182152752A006E7585 /* AnyEncodable.swift */,
 				E7B774152152752A006E7585 /* URL+APIAdapter.swift */,
@@ -584,6 +590,7 @@
 				E7197F77223510FF0059A54A /* MultipartBodyPart.swift in Sources */,
 				E7692824222431CE0031137D /* MultipartFormData.swift in Sources */,
 				E792629D219710A700CDBB7E /* URLSessionAPIAdapter.swift in Sources */,
+				E766870B2236FCFE0090DC08 /* APIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -610,6 +617,7 @@
 				E7197F79223510FF0059A54A /* MultipartBodyPart.swift in Sources */,
 				E7692826222431CE0031137D /* MultipartFormData.swift in Sources */,
 				E792629F219710A700CDBB7E /* URLSessionAPIAdapter.swift in Sources */,
+				E766870D2236FCFE0090DC08 /* APIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -627,6 +635,7 @@
 				E7197F7A223510FF0059A54A /* MultipartBodyPart.swift in Sources */,
 				E7692827222431CE0031137D /* MultipartFormData.swift in Sources */,
 				E79262A0219710A700CDBB7E /* URLSessionAPIAdapter.swift in Sources */,
+				E766870E2236FCFE0090DC08 /* APIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -644,6 +653,7 @@
 				E7197F78223510FF0059A54A /* MultipartBodyPart.swift in Sources */,
 				E7692825222431CE0031137D /* MultipartFormData.swift in Sources */,
 				E792629E219710A700CDBB7E /* URLSessionAPIAdapter.swift in Sources */,
+				E766870C2236FCFE0090DC08 /* APIError.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/APIAdapter+Types.swift
+++ b/Sources/APIAdapter+Types.swift
@@ -6,26 +6,6 @@
 //  Copyright © 2018 FUNTASTY Digital s.r.o. All rights reserved.
 //
 
-import struct Foundation.Data
-
-/// Standard API error returned in `APIResult` when no custom error
-/// was parsed in the `APIAdapter` first and the response from server
-/// was invalid.
-public enum APIError: Error {
-    /// Undefined error. Return code is less than 400, but no
-    /// request was received.
-    case noResponse
-    /// Error raised by NSURLSession corresponding to NSURLErrorCancelled at
-    /// domain NSURLErrorDomain.
-    case cancelled
-    /// Error code returned by `APIAdapter`. Thrown when request fails
-    /// with return code larger or equal to 400.
-    case errorCode(Int, Data?)
-    /// Multipart body part error, when the stream for the part
-    /// or the temporary request body stream cannot be opened.
-    case multipartStreamCannotBeOpened
-}
-
 /// Generic result type for API responses.
 /// No operations are defined for this type,
 /// it should be used manually or not at all

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -16,23 +16,20 @@ public protocol APIError: Error {
 /// was parsed in the `APIAdapter` first and the response from server
 /// was invalid.
 public enum StandardAPIError: APIError {
-    /// Undefined error. Return code is less than 400, but no
-    /// request was received.
-    case noResponse
     /// Error raised by NSURLSession corresponding to NSURLErrorCancelled at
     /// domain NSURLErrorDomain.
     case cancelled
-    /// Error code returned by `APIAdapter`. Thrown when request fails
-    /// with return code larger or equal to 400.
-    case client(Int, Data?)
-    /// Error code returned by `APIAdapter`. Thrown when request fails
-    /// with return code larger or equal to 400.
+    /// Connection error when no response and data was received.
+    case connection(Error)
+    /// Status code error when the response status code
+    /// is larger or equal to 500 and less than 600.
     case server(Int, Data?)
+    /// Status code error when the response status code
+    /// is larger or equal to 400 and less than 500.
+    case client(Int, Data?)
     /// Multipart body part error, when the stream for the part
     /// or the temporary request body stream cannot be opened.
     case multipartStreamCannotBeOpened
-    /// Connection error when no response and data was recieved.
-    case connection(Error)
 
     public init?(data: Data?, response: URLResponse?, error: Error?, decoder: JSONDecoder) {
         switch (data, response as? HTTPURLResponse, error) {

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -11,7 +11,7 @@ import struct Foundation.Data
 /// Standard API error returned in `APIResult` when no custom error
 /// was parsed in the `APIAdapter` first and the response from server
 /// was invalid.
-public enum APIError: Error {
+public enum StandardAPIError: APIError {
     /// Undefined error. Return code is less than 400, but no
     /// request was received.
     case noResponse

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -20,7 +20,7 @@ public enum APIError: Error {
     case cancelled
     /// Error code returned by `APIAdapter`. Thrown when request fails
     /// with return code larger or equal to 400.
-    case errorCode(Int, Data?)
+    case statusCode(Int, Data?)
     /// Multipart body part error, when the stream for the part
     /// or the temporary request body stream cannot be opened.
     case multipartStreamCannotBeOpened

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -1,0 +1,27 @@
+//
+//  APIError.swift
+//  FTAPIKit
+//
+//  Created by Matěj Kašpar Jirásek on 11/03/2019.
+//  Copyright © 2019 FUNTASTY Digital s.r.o. All rights reserved.
+//
+
+import struct Foundation.Data
+
+/// Standard API error returned in `APIResult` when no custom error
+/// was parsed in the `APIAdapter` first and the response from server
+/// was invalid.
+public enum APIError: Error {
+    /// Undefined error. Return code is less than 400, but no
+    /// request was received.
+    case noResponse
+    /// Error raised by NSURLSession corresponding to NSURLErrorCancelled at
+    /// domain NSURLErrorDomain.
+    case cancelled
+    /// Error code returned by `APIAdapter`. Thrown when request fails
+    /// with return code larger or equal to 400.
+    case errorCode(Int, Data?)
+    /// Multipart body part error, when the stream for the part
+    /// or the temporary request body stream cannot be opened.
+    case multipartStreamCannotBeOpened
+}

--- a/Sources/APIError.swift
+++ b/Sources/APIError.swift
@@ -24,26 +24,30 @@ public enum StandardAPIError: APIError {
     case cancelled
     /// Error code returned by `APIAdapter`. Thrown when request fails
     /// with return code larger or equal to 400.
-    case statusCode(Int, Data?)
+    case client(Int, Data?)
+    /// Error code returned by `APIAdapter`. Thrown when request fails
+    /// with return code larger or equal to 400.
+    case server(Int, Data?)
     /// Multipart body part error, when the stream for the part
     /// or the temporary request body stream cannot be opened.
     case multipartStreamCannotBeOpened
-    case underlyingError(Error)
+    /// Connection error when no response and data was recieved.
+    case connection(Error)
 
     public init?(data: Data?, response: URLResponse?, error: Error?, decoder: JSONDecoder) {
-        switch (data, response, error) {
-        case let (_, response as HTTPURLResponse, _) where response.statusCode == 204:
-            return nil
-        case let (.some, response as HTTPURLResponse, nil) where response.statusCode < 400:
-            return nil
+        switch (data, response as? HTTPURLResponse, error) {
         case let (_, _, error as NSError) where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled:
             self = .cancelled
         case let (_, _, error?):
-            self = .underlyingError(error)
-        case let (data, response as HTTPURLResponse, nil):
-            self = .statusCode(response.statusCode, data)
-        default:
-            self = .noResponse
+            self = .connection(error)
+        case let (data, response?, nil) where 400..<500 ~= response.statusCode:
+            self = .client(response.statusCode, data)
+        case let (data, response?, nil) where 500..<600 ~= response.statusCode:
+            self = .server(response.statusCode, data)
+        case (_, .some, nil), (.some, nil, nil):
+            return nil
+        case (nil, nil, nil):
+            fatalError("No response, data or error was returned from URLSession")
         }
     }
 }

--- a/Sources/MultipartBodyPart.swift
+++ b/Sources/MultipartBodyPart.swift
@@ -59,7 +59,7 @@ public struct MultipartBodyPart: Hashable {
     /// - Throws: `APIError.multipartStreamCannotBeOpened` if stream was not created from the file.
     public init(name: String, url: URL) throws {
         guard let inputStream = InputStream(url: url) else {
-            throw APIError.multipartStreamCannotBeOpened
+            throw StandardAPIError.multipartStreamCannotBeOpened
         }
         self.headers = [
             "Content-Type": url.mimeType,

--- a/Sources/MultipartFormData.swift
+++ b/Sources/MultipartFormData.swift
@@ -35,14 +35,14 @@ struct MultipartFormData {
     func inputStream() throws -> InputStream {
         try outputStream()
         guard let inputStream = InputStream(url: temporaryUrl) else {
-            throw APIError.multipartStreamCannotBeOpened
+            throw StandardAPIError.multipartStreamCannotBeOpened
         }
         return inputStream
     }
 
     private func outputStream() throws {
         guard let outputStream = OutputStream(url: temporaryUrl, append: false) else {
-            throw APIError.multipartStreamCannotBeOpened
+            throw StandardAPIError.multipartStreamCannotBeOpened
         }
         outputStream.open()
         defer {

--- a/Sources/URLSessionAPIAdapter.swift
+++ b/Sources/URLSessionAPIAdapter.swift
@@ -10,11 +10,6 @@ import Foundation
 
 /// Standard and default implementation of `APIAdapter` protocol using `URLSession`.
 public final class URLSessionAPIAdapter: APIAdapter {
-
-    /// Custom error constructor typealias receiving values from data task execution
-    /// and JSON decoder, if it needs to decode custom error from returned JSON.
-    public typealias ErrorConstructor = (Data?, URLResponse?, Error?, JSONDecoder) -> Error?
-
     public weak var delegate: APIAdapterDelegate?
 
     private let urlSession: URLSession
@@ -23,7 +18,7 @@ public final class URLSessionAPIAdapter: APIAdapter {
     private let jsonEncoder: JSONEncoder
     private let jsonDecoder: JSONDecoder
 
-    private let customErrorConstructor: ErrorConstructor?
+    private let errorType: APIError.Type
 
     private var runningRequestCount: UInt = 0 {
         didSet {
@@ -44,11 +39,11 @@ public final class URLSessionAPIAdapter: APIAdapter {
     ///                             the standard `APIError`, but to handle the errors our own way.
     ///   - urlSession: Optional URL session (otherwise the standard one will be used). Used mainly if we need
     ///                 our own `URLSessionConfiguration` or another way of caching (ephemeral session).
-    public init(baseUrl: URL, jsonEncoder: JSONEncoder = JSONEncoder(), jsonDecoder: JSONDecoder = JSONDecoder(), customErrorConstructor: ErrorConstructor? = nil, urlSession: URLSession = .shared) {
+    public init(baseUrl: URL, jsonEncoder: JSONEncoder = JSONEncoder(), jsonDecoder: JSONDecoder = JSONDecoder(), errorType: APIError.Type = StandardAPIError.self, urlSession: URLSession = .shared) {
         self.baseUrl = baseUrl
         self.jsonDecoder = jsonDecoder
         self.jsonEncoder = jsonEncoder
-        self.customErrorConstructor = customErrorConstructor
+        self.errorType = errorType
         self.urlSession = urlSession
     }
 
@@ -113,24 +108,11 @@ public final class URLSessionAPIAdapter: APIAdapter {
     }
 
     private func resumeDataTask(with request: URLRequest, completion: @escaping (APIResult<Data>) -> Void) -> URLSessionTask {
-        let task = urlSession.dataTask(with: request) { [customErrorConstructor, jsonDecoder] data, response, error in
-            if let constructor = customErrorConstructor, let error = constructor(data, response, error, jsonDecoder) {
+        let task = urlSession.dataTask(with: request) { [jsonDecoder, errorType] data, response, error in
+            if let error = errorType.init(data: data, response: response, error: error, decoder: jsonDecoder) {
                 completion(.error(error))
-                return
-            }
-            switch (data, response, error) {
-            case let (_, response as HTTPURLResponse, _) where response.statusCode == 204:
-                completion(.value(Data()))
-            case let (data?, response as HTTPURLResponse, nil) where response.statusCode < 400:
-                completion(.value(data))
-            case let (_, _, error as NSError) where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled:
-                completion(.error(APIError.cancelled))
-            case let (_, _, error?):
-                completion(.error(error))
-            case let (data, response as HTTPURLResponse, nil):
-                completion(.error(APIError.statusCode(response.statusCode, data)))
-            default:
-                completion(.error(APIError.noResponse))
+            } else {
+                completion(.value(data ?? Data()))
             }
         }
         task.resume()

--- a/Sources/URLSessionAPIAdapter.swift
+++ b/Sources/URLSessionAPIAdapter.swift
@@ -35,8 +35,8 @@ public final class URLSessionAPIAdapter: APIAdapter {
     ///   - baseUrl: Base URI for the server for all API calls this API adapter will be executing.
     ///   - jsonEncoder: Optional JSON encoder used for serialization of JSON models.
     ///   - jsonDecoder: Optional JSON decoder used for deserialization of JSON models.
-    ///   - customErrorConstructor: Optional custom error constructor if we want the API adapter to not return
-    ///                             the standard `APIError`, but to handle the errors our own way.
+    ///   - errorType: If we want custom method for error handling instead of returning `StandardAPIError`
+    ///                This type needs to implement `APIError` protocol and its optional init requirement.
     ///   - urlSession: Optional URL session (otherwise the standard one will be used). Used mainly if we need
     ///                 our own `URLSessionConfiguration` or another way of caching (ephemeral session).
     public init(baseUrl: URL, jsonEncoder: JSONEncoder = JSONEncoder(), jsonDecoder: JSONDecoder = JSONDecoder(), errorType: APIError.Type = StandardAPIError.self, urlSession: URLSession = .shared) {

--- a/Sources/URLSessionAPIAdapter.swift
+++ b/Sources/URLSessionAPIAdapter.swift
@@ -128,7 +128,7 @@ public final class URLSessionAPIAdapter: APIAdapter {
             case let (_, _, error?):
                 completion(.error(error))
             case let (data, response as HTTPURLResponse, nil):
-                completion(.error(APIError.errorCode(response.statusCode, data)))
+                completion(.error(APIError.statusCode(response.statusCode, data)))
             default:
                 completion(.error(APIError.noResponse))
             }

--- a/Tests/FTAPIKitTests/APIAdapterTests.swift
+++ b/Tests/FTAPIKitTests/APIAdapterTests.swift
@@ -96,7 +96,7 @@ final class APIAdapterTests: XCTestCase {
             let path = "get"
         }
 
-        struct CustomError: Error {
+        struct CustomError: APIError {
             private init() {}
 
             init?(data: Data?, response: URLResponse?, error: Error?, decoder: JSONDecoder) {
@@ -105,7 +105,7 @@ final class APIAdapterTests: XCTestCase {
         }
 
         let delegate = MockupAPIAdapterDelegate()
-        var adapter: APIAdapter = URLSessionAPIAdapter(baseUrl: URL(string: "http://httpbin.org/")!, customErrorConstructor: CustomError.init)
+        var adapter: APIAdapter = URLSessionAPIAdapter(baseUrl: URL(string: "http://httpbin.org/")!, errorType: CustomError.self)
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in

--- a/Tests/FTAPIKitTests/APIAdapterTests.swift
+++ b/Tests/FTAPIKitTests/APIAdapterTests.swift
@@ -206,7 +206,7 @@ final class APIAdapterTests: XCTestCase {
         let expectation = self.expectation(description: "Result")
         adapter.dataTask(response: Endpoint(), creation: { $0.cancel() }, completion: { result in
             expectation.fulfill()
-            guard case .error(APIError.cancelled) = result else {
+            guard case .error(StandardAPIError.cancelled) = result else {
                 XCTFail("Task not cancelled")
                 return
             }

--- a/Tests/FTAPIKitTests/APIAdapterTests.swift
+++ b/Tests/FTAPIKitTests/APIAdapterTests.swift
@@ -29,10 +29,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -65,10 +65,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case .value = result {
                 XCTFail("Non-existing domain must fail")
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -83,10 +83,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -109,12 +109,12 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTAssertTrue(error is CustomError)
             } else {
                 XCTFail("Custom error must be returned")
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -135,10 +135,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -170,10 +170,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(response: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -205,13 +205,12 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.dataTask(response: Endpoint(), creation: { $0.cancel() }, completion: { result in
-            expectation.fulfill()
             guard case .error(StandardAPIError.cancelled) = result else {
                 XCTFail("Task not cancelled")
                 return
             }
+            expectation.fulfill()
         })
-
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -241,13 +240,13 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(response: endpoint) { result in
-            expectation.fulfill()
             switch result {
             case .value(let response):
                 XCTAssertEqual(user, response.json)
             case .error(let error):
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -273,10 +272,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(response: endpoint) { result in
-            expectation.fulfill()
             if case .value = result {
                 XCTFail("Received valid value, decoding must fail")
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }
@@ -293,12 +292,11 @@ final class APIAdapterTests: XCTestCase {
 
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
-
         wait(for: [expectation], timeout: timeout)
     }
 
@@ -329,10 +327,10 @@ final class APIAdapterTests: XCTestCase {
         adapter.delegate = delegate
         let expectation = self.expectation(description: "Result")
         adapter.request(data: Endpoint()) { result in
-            expectation.fulfill()
             if case let .error(error) = result {
                 XCTFail(error.localizedDescription)
             }
+            expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
     }


### PR DESCRIPTION
Closes #22.

- Change `APIError` to protocol
- Update error cases
- Change passing of error constructor to passing of type
- Fix expectation fulfillment order