### PR TITLE
Upload request type

### DIFF
--- a/Sources/APIAdapter+Types.swift
+++ b/Sources/APIAdapter+Types.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018 FUNTASTY Digital s.r.o. All rights reserved.
 //
 
+import Foundation
+
 /// Generic result type for API responses.
 /// No operations are defined for this type,
 /// it should be used manually or not at all
@@ -70,4 +72,15 @@ public enum RequestType {
     /// The parameters will be encoded using Base64 encoding
     /// and sent in request body.
     case base64Upload
+    /// For sending raw body input streams, uploading files etc.
+    case upload(body: InputStream, mimeType: String)
+}
+
+public extension RequestType {
+    static func upload(url: URL) throws -> RequestType {
+        guard let inputStream = InputStream(url: url) else {
+            throw StandardAPIError.multipartStreamCannotBeOpened
+        }
+        return .upload(body: inputStream, mimeType: url.mimeType)
+    }
 }

--- a/Sources/APIAdapter+Types.swift
+++ b/Sources/APIAdapter+Types.swift
@@ -48,11 +48,6 @@ public enum HTTPMethod: String, CustomStringConvertible {
     }
 }
 
-/// Alias for URL query or URL encoded parameter dictionary.
-public typealias HTTPParameters = [String: String]
-/// Alias for HTTP header dictionary.CustomStringConvertible
-public typealias HTTPHeaders = [String: String]
-
 /// Type of the API request. JSON body and multipart requests
 /// have associated values which are used as a body. The other
 /// types only describe how the `HTTPParameters` are encoded.

--- a/Sources/APIEndpoint.swift
+++ b/Sources/APIEndpoint.swift
@@ -24,7 +24,7 @@ public protocol APIEndpoint {
     /// URL parameters is string dictionary sent either as URL query, multipart,
     /// JSON parameters or URL/Base64 encoded body. The `type` parameter of `APIEndpoint`
     /// protocol describes the way how to send the parameters.
-    var parameters: HTTPParameters { get }
+    var parameters: [String: String] { get }
 
     /// HTTP method/verb describing the action.
     var method: HTTPMethod { get }
@@ -42,7 +42,7 @@ public protocol APIEndpoint {
 }
 
 public extension APIEndpoint {
-    var parameters: HTTPParameters {
+    var parameters: [String: String] {
         return [:]
     }
 

--- a/Sources/URLRequest+APIAdapter.swift
+++ b/Sources/URLRequest+APIAdapter.swift
@@ -21,6 +21,8 @@ extension URLRequest {
             try setMultipart(parameters: parameters, files: files)
         case .base64Upload:
             appendBase64(parameters: parameters)
+        case let .upload(stream, mimeType):
+            setUpload(stream: stream, mimeType: mimeType, parameters: parameters)
         case .urlQuery:
             url?.appendQuery(parameters: parameters)
         }
@@ -33,8 +35,13 @@ extension URLRequest {
         setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
     }
 
-    private mutating func setMultipart(parameters: HTTPParameters = [:], files: [MultipartBodyPart] = [], boundary: String = "FTAPIKit-" + UUID().uuidString) throws {
+    private mutating func setUpload(stream: InputStream, mimeType: String, parameters: [String: String]) {
+        setValue(mimeType, forHTTPHeaderField: "Content-Type")
+        url?.appendQuery(parameters: parameters)
+        httpBodyStream = stream
+    }
 
+    private mutating func setMultipart(parameters: [String: String] = [:], files: [MultipartBodyPart] = [], boundary: String = "FTAPIKit-" + UUID().uuidString) throws {
         let parameterParts = parameters.map(MultipartBodyPart.init)
         let multipartData = MultipartFormData(parts: parameterParts + files, boundary: "--" + boundary)
 

--- a/Sources/URLRequest+APIAdapter.swift
+++ b/Sources/URLRequest+APIAdapter.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension URLRequest {
-    mutating func setRequestType(_ requestType: RequestType, parameters: HTTPParameters, using jsonEncoder: JSONEncoder) throws {
+    mutating func setRequestType(_ requestType: RequestType, parameters: [String: String], using jsonEncoder: JSONEncoder) throws {
         switch requestType {
         case .jsonBody(let encodable):
             try setJSONBody(encodable: encodable, parameters: parameters, using: jsonEncoder)
@@ -17,7 +17,7 @@ extension URLRequest {
             setURLEncoded(parameters: parameters)
         case .jsonParams:
             setJSON(parameters: parameters, using: jsonEncoder)
-        case let .multipart(files):
+        case .multipart(let files):
             try setMultipart(parameters: parameters, files: files)
         case .base64Upload:
             appendBase64(parameters: parameters)
@@ -28,7 +28,7 @@ extension URLRequest {
         }
     }
 
-    private mutating func appendBase64(parameters: HTTPParameters) {
+    private mutating func appendBase64(parameters: [String: String]) {
         var urlComponents = URLComponents()
         urlComponents.queryItems = parameters.map(URLQueryItem.init)
         httpBody = urlComponents.query?.data(using: String.Encoding.ascii, allowLossyConversion: true)
@@ -53,20 +53,20 @@ extension URLRequest {
         }
     }
 
-    private mutating func setJSON(parameters: HTTPParameters, body: Data? = nil, using jsonEncoder: JSONEncoder) {
+    private mutating func setJSON(parameters: [String: String], body: Data? = nil, using jsonEncoder: JSONEncoder) {
         setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
         httpBody = body
         url?.appendQuery(parameters: parameters)
     }
 
-    private mutating func setURLEncoded(parameters: HTTPParameters) {
+    private mutating func setURLEncoded(parameters: [String: String]) {
         var urlComponents = URLComponents()
         urlComponents.queryItems = parameters.map(URLQueryItem.init)
         httpBody = urlComponents.query?.data(using: .ascii, allowLossyConversion: true)
         setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
     }
 
-    private mutating func setJSONBody(encodable: Encodable, parameters: HTTPParameters, using jsonEncoder: JSONEncoder) throws {
+    private mutating func setJSONBody(encodable: Encodable, parameters: [String: String], using jsonEncoder: JSONEncoder) throws {
         let body = try jsonEncoder.encode(AnyEncodable(encodable))
         setJSON(parameters: parameters, body: body, using: jsonEncoder)
     }

--- a/Tests/FTAPIKitTests/APIAdapterTests.swift
+++ b/Tests/FTAPIKitTests/APIAdapterTests.swift
@@ -369,6 +369,29 @@ final class APIAdapterTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
+    func testUpload() {
+        struct Endpoint: APIEndpoint {
+            let type: RequestType = try! .upload(url: Bundle(for: APIAdapterTests.self).url(forResource: "MockupBodyPart", withExtension: "jpg")!)
+            let parameters = [
+                "someParameter": "someValue"
+            ]
+            let path = "anything"
+            let method: HTTPMethod = .put
+        }
+
+        let delegate = MockupAPIAdapterDelegate()
+        var adapter: APIAdapter = apiAdapter()
+        adapter.delegate = delegate
+        let expectation = self.expectation(description: "Result")
+        adapter.request(data: Endpoint()) { result in
+            if case let .error(error) = result {
+                XCTFail(error.localizedDescription)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: timeout)
+    }
+
     static var allTests = [
         ("testGet", testGet),
         ("testClientError", testClientError),
@@ -381,6 +404,7 @@ final class APIAdapterTests: XCTestCase {
         ("testValidJSONRequestResponse", testValidJSONRequestResponse),
         ("testInvalidJSONRequestResponse", testInvalidJSONRequestResponse),
         ("testAuthorization", testAuthorization),
-        ("testMultipartData", testMultipartData)
+        ("testMultipartData", testMultipartData),
+        ("testUpload", testUpload)
     ]
 }

--- a/Tests/FTAPIKitTests/APIAdapterTests.swift
+++ b/Tests/FTAPIKitTests/APIAdapterTests.swift
@@ -155,7 +155,7 @@ final class APIAdapterTests: XCTestCase {
     func testURLEncodedPost() {
         struct Endpoint: APIEndpoint {
             let data: RequestType = .urlEncoded
-            let parameters: HTTPParameters = [
+            let parameters = [
                 "someParameter": "someValue",
                 "anotherParameter": "anotherValue"
             ]
@@ -337,7 +337,7 @@ final class APIAdapterTests: XCTestCase {
     func testMultipartData() {
         struct MockupUrl {
             let url: URL = Bundle(for: APIAdapterTests.self).url(forResource: "MockupBodyPart", withExtension: "jpg")!
-            let headers: [String: String] = [
+            let headers = [
                 "Content-Disposition": "form-data; name=jpegFile",
                 "Content-Type": "image/jpeg"
             ]
@@ -349,7 +349,7 @@ final class APIAdapterTests: XCTestCase {
                 MultipartBodyPart(headers: MockupUrl().headers, data: try! Data(contentsOf: MockupUrl().url)),
                 MultipartBodyPart(headers: MockupUrl().headers, inputStream: InputStream(url: MockupUrl().url)!)
             ])
-            let parameters: HTTPParameters = [
+            let parameters = [
                 "someParameter": "someValue"
             ]
             let path = "post"


### PR DESCRIPTION
APIKit allowed us only to upload multipart files, this PR adds support of simple upload using PUT request. (Used for example for uploading files to Amazon S3 using resigned links.)